### PR TITLE
fix gcc8.2/gcc9 compiling error: Corrected typedef so that map value_type and allocator are the same

### DIFF
--- a/src/FTRL/ftrl_model.h
+++ b/src/FTRL/ftrl_model.h
@@ -193,7 +193,8 @@ int ftrl_model_unit<T>::factor_num;
 
 
 template<typename T>
-using my_hash_map = unordered_map<const char*, ftrl_model_unit<T>, my_hash, my_equal, my_allocator<pair<const char*, ftrl_model_unit<T> >, T, ftrl_model_unit> >;
+using my_hash_map = unordered_map<const char*, ftrl_model_unit<T>, my_hash, my_equal, 
+    my_allocator<pair<const char* const, ftrl_model_unit<T> >, T, ftrl_model_unit> >;
 
 
 template<typename T>

--- a/src/FTRL/predict_model.h
+++ b/src/FTRL/predict_model.h
@@ -118,7 +118,8 @@ int predict_model_unit<T>::factor_num;
 
 
 template<typename T>
-using predict_hash_map = unordered_map<const char*, predict_model_unit<T>, my_hash, my_equal, my_allocator<pair<const char*, predict_model_unit<T> >, T, predict_model_unit> >;
+using predict_hash_map = unordered_map<const char*, predict_model_unit<T>, my_hash, my_equal, 
+    my_allocator<pair<const char* const, predict_model_unit<T> >, T, predict_model_unit> >;
 
 
 template<typename T>


### PR DESCRIPTION
in gcc8.2 compiling, it failed on the error:

```bash
/home/opt/compiler/gcc-8.2/gcc-8.2/include/c++/8.2.0/bits/hashtable.h: In instantiation of ‘class std::_Hashtable<const char*, std::pair<const char* const, predict_model_unit<float> >, my_allocator<std::pair<const char*, predict_model_unit<float> >, float, predict_model_unit>, std::__detail::_Select1st, my_equal, my_hash, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >’:
/home/opt/compiler/gcc-8.2/gcc-8.2/include/c++/8.2.0/bits/unordered_map.h:105:18:   required from ‘class std::unordered_map<const char*, predict_model_unit<float>, my_hash, my_equal, my_allocator<std::pair<const char*, predict_model_unit<float> >, float, predict_model_unit> >’
src/FTRL/predict_model.h:129:25:   required from ‘class predict_model<float>’
src/FTRL/ftrl_predictor.h:88:14:   required from ‘ftrl_predictor<T>::ftrl_predictor(const predictor_option&) [with T = float]’
fm_predict.cpp:29:23:   required from ‘int predict(const predictor_option&) [with T = float]’
fm_predict.cpp:55:34:   required from here
/home/opt/compiler/gcc-8.2/gcc-8.2/include/c++/8.2.0/bits/hashtable.h:192:21: 错误：static assertion failed: unordered container must have the same value_type as its allocator
       static_assert(is_same<typename _Alloc::value_type, _Value>{},
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/opt/compiler/gcc-8.2/gcc-8.2/include/c++/8.2.0/bits/hashtable.h:280:21: 错误：static assertion failed: Cache the hash code or qualify your functors involved in hash code and bucket index computation with noexcept
       static_assert(noexcept(declval<const __hash_code_base_access&>()
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ._M_bucket_index((const __node_type*)nullptr,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            (std::size_t)0)),
            ~~~~~~~~~~~~~~~~
```

After search,  we found the link: [Corrected typedef so that map value_type and allocator are the same](https://github.com/raulmur/ORB_SLAM2/pull/585), it has the same error and compiler is gcc 9.
so we increase the influence to gcc9, and then push the PR
